### PR TITLE
jaegar と Vaxila 両方に trace を投稿する

### DIFF
--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -25,12 +25,24 @@ services:
     command: ["all"]
     environment:
       #- OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-vaxila.mackerelio.com
-      - OTEL_EXPORTER_OTLP_HEADERS=Mackerel-Api-Key=${MACKEREL_VAXILA_APIKEY}
+      #- OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-vaxila.mackerelio.com
+      #- OTEL_EXPORTER_OTLP_HEADERS=Mackerel-Api-Key=${MACKEREL_VAXILA_APIKEY}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4319
     networks:
       - jaeger-example
     depends_on:
       - jaeger
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    volumes:
+      - ./otel-col.yml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - "4319:4319"
+    environment:
+      - MACKEREL_VAXILA_APIKEY
+    networks:
+      - jaeger-example
+      
 networks:
   jaeger-example:

--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       #- OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
       - OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-vaxila.mackerelio.com
       - OTEL_EXPORTER_OTLP_HEADERS=Mackerel-Api-Key=${MACKEREL_VAXILA_APIKEY}
-
     networks:
       - jaeger-example
     depends_on:

--- a/examples/hotrod/otel-col.yml
+++ b/examples/hotrod/otel-col.yml
@@ -1,0 +1,43 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4319"
+processors:
+  batch:
+    # Vaxila では 6MB 以上のリクエストを受け付けません。
+    # そのため、リクエストあたりの最大スパン数を適当に設定します。
+    # スパンはトレースにおける作業または操作の単位です。
+    # データベースへのクエリ実行やアプリケーションの処理の 1 部分などをスパンとして表現できます。
+    # https://opentelemetry.io/docs/concepts/signals/traces/#spans
+    # Vaxila には Mackerel の 1 オーガニゼーションあたり月間 500 万スパンまで送信できます
+    timeout: 1m
+    send_batch_size: 5000
+    send_batch_max_size: 5000
+  # resource/namespace:
+  #   attributes:
+  #   - key: service.namespace
+  #     value: "kmuto/jeager/hotrod"
+  #     action: upsert
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 500
+    spike_limit_mib: 100
+
+exporters:
+  otlphttp/vaxila:
+    endpoint: https://otlp-vaxila.mackerelio.com
+    compression: gzip
+    headers:
+      Mackerel-Api-Key: ${env:MACKEREL_VAXILA_APIKEY}
+  otlphttp/jeager:
+    endpoint: http://jaeger:4318
+    compression: gzip
+    tls:
+      insecure: true
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch,memory_limiter]
+      exporters: [otlphttp/vaxila,otlphttp/jeager]

--- a/examples/hotrod/otel-col.yml
+++ b/examples/hotrod/otel-col.yml
@@ -14,11 +14,11 @@ processors:
     timeout: 1m
     send_batch_size: 5000
     send_batch_max_size: 5000
-  # resource/namespace:
-  #   attributes:
-  #   - key: service.namespace
-  #     value: "kmuto/jeager/hotrod"
-  #     action: upsert
+  resource/namespace:
+    attributes:
+    - key: service.namespace
+      value: "kmuto/jaeger/hotrod"
+      action: upsert
   memory_limiter:
     check_interval: 1s
     limit_mib: 500
@@ -39,5 +39,5 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch,memory_limiter]
+      processors: [resource/namespace,batch,memory_limiter]
       exporters: [otlphttp/vaxila,otlphttp/jeager]


### PR DESCRIPTION
[OpenTelemetryのトレースを活用してボトルネックを探す体験をしてみた - kmuto’s blog](https://kmuto.hatenablog.com/entry/2024/09/16/163800) を参考に起動して試してみました。

比較ができたほうがいいなと思ったので、両方に投稿するようにローカルで otel-collector を起動させる変更です。

jaeger はローカルのため永続化しなければ停止することでデータを消せますが、vaxila はクラウドサービスであることから既存利用との取りまわしなどが大変になる可能性があるため、`service.namespace = kmuto/jaeger/hotrod` という namespace を付与して区別できるようにしました。